### PR TITLE
Add instance_path to FkOrUrlFieldFilter to enable retrieval of attributes of local objects

### DIFF
--- a/django_loose_fk/filters.py
+++ b/django_loose_fk/filters.py
@@ -37,6 +37,10 @@ class FkOrUrlFieldFilter(django_filters.CharFilter):
 
     def __init__(self, *args, **kwargs):
         self.queryset = kwargs.pop("queryset")
+
+        # Specified path of attributes that must be traversed to retrieve the
+        # desired object
+        self.instance_path = kwargs.pop("instance_path", None)
         super().__init__(*args, **kwargs)
 
     def filter(self, qs, value):
@@ -53,6 +57,9 @@ class FkOrUrlFieldFilter(django_filters.CharFilter):
 
         if local:
             local_object = get_resource_for_path(parsed.path)
+            if self.instance_path:
+                for bit in self.instance_path.split("."):
+                    local_object = getattr(local_object, bit)
             filters = {f"{model_field.fk_field}__{self.lookup_expr}": local_object}
         else:
             filters = {f"{model_field.url_field}__{self.lookup_expr}": value}

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,0 +1,46 @@
+from django.test import override_settings
+
+import pytest
+from django_filters.rest_framework.filterset import FilterSet
+from rest_framework.reverse import reverse
+from testapp.api import ZaakFilterSet, ZaakViewSet
+from testapp.models import Zaak, ZaakType
+
+from django_loose_fk.filters import FkOrUrlFieldFilter
+
+pytestmark = pytest.mark.django_db()
+
+
+class ZaakFilter(FilterSet):
+    zaaktype = FkOrUrlFieldFilter(queryset=ZaakType.objects.all(), instance_path="name")
+
+    class Meta:
+        model = Zaak
+        fields = ("zaaktype",)
+
+
+@override_settings(ALLOWED_HOSTS=["testserver.com"])
+def test_fk_or_url_field_filter_with_instance_path(api_client):
+    ZaakViewSet.filterset_class = ZaakFilter
+
+    zaaktype = ZaakType.objects.create(name=1)
+    zaaktype_uri = reverse("zaaktype-detail", kwargs={"pk": zaaktype.pk})
+    zaaktype_url = f"http://testserver.com{zaaktype_uri}"
+
+    zaak = Zaak.objects.create(name="bla", zaaktype=zaaktype)
+    zaak_uri = reverse("zaak-detail", kwargs={"pk": zaak.pk})
+    zaak_url = f"http://testserver.com{zaak_uri}"
+
+    url = reverse("zaak-list")
+
+    # Filtering on Zaaktype should first resolve the URL to the correct
+    # ZaakType in the database, then it will use the instance_path to find
+    # the attribute that we're interested in. which is `name` in this case
+    response = api_client.get(
+        url, {"zaaktype": zaaktype_url}, HTTP_HOST="testserver.com"
+    )
+
+    ZaakViewSet.filterset_class = ZaakFilterSet
+
+    assert response.status_code == 200
+    assert response.data == [{"url": zaak_url, "zaaktype": zaaktype_url, "name": "bla"}]


### PR DESCRIPTION
to fix filtering `ZaakInformatieObject` on `informatieobject` in openzaak, because a url that resolves to an `EnkelvoudigInformatieObject` is used to filter with, but `ZaakInformatieObject` has a loose foreign key to `EnkelvoudigInformatieObjectCanonical`