### PR TITLE
Remove the portion of the url prefix

### DIFF
--- a/django_loose_fk/utils.py
+++ b/django_loose_fk/utils.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.db import models
 from django.http import HttpRequest
-from django.urls import Resolver404, get_resolver
+from django.urls import Resolver404, get_resolver, get_script_prefix
 
 from rest_framework import viewsets
 from rest_framework.request import Request
@@ -37,6 +37,9 @@ def get_resource_for_path(path: str) -> models.Model:
     """
     if settings.FORCE_SCRIPT_NAME and path.startswith(settings.FORCE_SCRIPT_NAME):
         path = path[len(settings.FORCE_SCRIPT_NAME) :]
+
+    path = path.replace(get_script_prefix(), '/', 1)
+
     viewset = get_viewset_for_path(path)
 
     queryset = viewset.get_queryset()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,7 @@
 """
 Test the API interface to handle local/remote references.
 """
+from unittest.mock import patch
 import pytest
 import requests_mock
 from rest_framework.reverse import reverse
@@ -81,6 +82,21 @@ def test_write_invalid_local_url(api_client):
     assert response.status_code == 400
     assert "zaaktype" in response.data
     assert response.data["zaaktype"][0].code == "does_not_exist"
+
+
+@patch('django_loose_fk.utils.get_script_prefix', return_value='/subpath/')
+def test_write_local_url_with_subpath(mock, api_client):
+    url = reverse("zaak-list")
+    zaaktype = ZaakType.objects.create(name="test")
+    zaaktype_url = reverse("zaaktype-detail", kwargs={"pk": zaaktype.pk})
+
+    data = {"name": "test", "zaaktype": f"http://testserver/subpath{zaaktype_url}"}
+
+    response = api_client.post(url, data)
+
+    assert response.status_code == 201
+    zaak = Zaak.objects.get()
+    assert zaak.zaaktype == zaaktype
 
 
 def test_filter_zaaktype_remote_url(api_client):


### PR DESCRIPTION
Fixes and issue initially found here: https://sentry.maykinmedia.nl/maykin-media/open-zaak-swf-test/issues/282793/?query=is%3Aunresolved

The cause of the bug is that open-zaak was not mounted under the root of the webserver, it was mounted under `/zgw`.  This means that when the resource for the path the resource was not being found since the path contained `/zgw`.

This fix uses `get_script_prefix` https://docs.djangoproject.com/en/2.2/ref/urlresolvers/#get-script-prefix to remoe any prefix from the url so that the look works properly.