### PR TITLE
:zap: Minor optimizations to DRF fields and model fields

### DIFF
--- a/django_loose_fk/fields.py
+++ b/django_loose_fk/fields.py
@@ -5,6 +5,7 @@ from django.core import checks
 from django.db import models
 from django.db.models import Field
 from django.db.models.base import ModelBase, Options
+from django.utils.functional import cached_property
 
 from .constraints import FkOrURLFieldConstraint
 from .loaders import BaseLoader, default_loader
@@ -106,7 +107,7 @@ class FkOrURLField(models.Field):
             options.original_attrs["constraints"] = options.constraints
         return
 
-    @property
+    @cached_property
     def _fk_field(self) -> models.ForeignKey:
         # get the actual fields - uses private API because the app registry isn't
         # ready yet
@@ -114,7 +115,7 @@ class FkOrURLField(models.Field):
         _fields = {field.name: field for field in self.model._meta.fields}
         return _fields[self.fk_field]
 
-    @property
+    @cached_property
     def _url_field(self) -> models.URLField:
         # get the actual fields - uses private API because the app registry isn't
         # ready yet


### PR DESCRIPTION
fixes https://github.com/open-zaak/open-zaak/issues/1954 partially

previously the local field was initialized in to_representation, which would result in duplicate inits of the same field (e.g. when serializing a list of 100 objects of a model that has one FKOrURLField, it would do the same initialization 100 times

Related issue: https://github.com/open-zaak/open-zaak/issues/1954
Related PR in open zaak: https://github.com/open-zaak/open-zaak/pull/1957

From local runs as well as in CI, it seems to remove about 25-35ms from the mean response times when 100+ zaken are returned (from a baseline mean response time of 214ms, so that's between about 11% and 16%)